### PR TITLE
chore: add .stowrc

### DIFF
--- a/.stowrc
+++ b/.stowrc
@@ -1,0 +1,1 @@
+--target=$HOME


### PR DESCRIPTION
Add .stowrc file to specify the Linus home directory as the default target.